### PR TITLE
Make code python3 compliant; add flag for headless oauth; add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-alpine
+
+# repo issue
+#RUN apk --update add gcc musl-dev libxml2-dev libxslt-dev
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY drive.py .
+
+ENTRYPOINT [ "python", "./drive.py" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Via http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+build: docker
+
+docker: ## Create docker container
+	docker build -t google-drive-backup .

--- a/README.md
+++ b/README.md
@@ -30,3 +30,36 @@ Following command line options are available.
 **--logfile** - Path to the file to which the logs should be written to. By default, writes to `drive.log` in the current directory. The file will be overwritten every time the script is run.
 
 **--drive_id** ID of the folder which you want to download. By default, entire "My Drive" is downloaded.
+
+**--noauth_local_webserver** Allow to fetch google oauth credentials if you run this script on a system without a browser
+
+
+## Running google-drive-backup in Docker
+
+### Create docker container
+```shell
+make build
+```
+
+### Fetch credentials
+```shell
+docker run --rm -it \
+    -v "$HOME/client_secret_gdrive-backup.json:/client_secrets.json" \
+    -v "/tmp/gdrive-creds.json:/drive.dat" \
+    google-drive-backup \
+    --noauth_local_webserver
+```
+
+### Synchronize files to local folder
+```shell
+docker run --rm -it \
+    -v "$HOME/client_secret_gdrive-backup.json:/client_secrets.json" \
+    -v "/tmp/gdrive-creds.json:/drive.dat" \
+    -v "/tmp/gdrive:/gdrive" \
+    -v "/tmp/logfile.txt:/logfile.txt" \
+    google-drive-backup \
+    --debug \
+    --destination /gdrive/ \
+    --logfile /logfile.txt \
+    --logging_level=DEBUG
+```

--- a/drive.py
+++ b/drive.py
@@ -66,16 +66,17 @@ gflags.DEFINE_string('destination', 'downloaded/', 'Destination folder location'
 gflags.DEFINE_boolean('debug', False, 'Log folder contents as being fetched' )
 gflags.DEFINE_string('logfile', 'drive.log', 'Location of file to write the log' )
 gflags.DEFINE_string('drive_id', 'root', 'ID of the folder whose contents are to be fetched' )
+gflags.DEFINE_boolean('noauth_local_webserver', False, 'Google authentication if the browser is not on the local system' )
 
 
 def open_logfile():
     if not re.match( '^/', FLAGS.logfile ):
         FLAGS.logfile = FLAGS.destination + FLAGS.logfile
     global LOG_FILE
-    LOG_FILE = open( FLAGS.logfile, 'w+' )
+    LOG_FILE = open( FLAGS.logfile, 'w+b' )
 
-def log(str):
-    LOG_FILE.write( (str + '\n').encode('utf8') )
+def log(log):
+    LOG_FILE.write( (log + '\n').encode('utf8') )
 
 def append_rename(path, count):
     without_slash = path.rstrip(os.sep)
@@ -83,7 +84,7 @@ def append_rename(path, count):
     if os.path.exists(try_path):
         append_rename(path, count + 1)
     else:
-	print([without_slash, try_path])
+        print([without_slash, try_path])
         os.rename(without_slash, try_path)
 
 def mkdir_p(path):
@@ -100,7 +101,7 @@ def mkdir_p(path):
 def ensure_dir(directory):
     if not os.path.exists(directory):
         log( "Creating directory: %s" % directory )
-	mkdir_p (directory)
+        mkdir_p (directory)
 
 def is_google_doc(drive_file):
     return True if re.match( '^application/vnd\.google-apps\..+', drive_file['mimeType'] ) else False
@@ -184,11 +185,11 @@ def download_file( service, drive_file, dest_path ):
             return False
         if resp.status == 200:
             try:
-                target = open( file_location, 'w+' )
+                target = open( file_location, 'w+b' )
             except:
                 log( "Could not open file %s for writing. Please check permissions." % file_location )
                 return False
-            target.write( content )
+            target.write(content)
             return True
         else:
             log( 'An error occurred: %s' % resp )
@@ -202,8 +203,8 @@ def main(argv):
     # Let the gflags module process the command-line arguments
     try:
         argv = FLAGS(argv)
-    except gflags.FlagsError, e:
-        print '%s\\nUsage: %s ARGS\\n%s' % (e, argv[0], FLAGS)
+    except gflags.FlagsError as e:
+        print('%s\\nUsage: %s ARGS\\n%s' % (e, argv[0], FLAGS))
         sys.exit(1)
 
     # Set the logging according to the command-line flag

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+google-api-python-client
+python-gflags


### PR DESCRIPTION
I added Docker support, made the code python3 compliant and added a flag for headless oauth.

One small change that snugged into it is also to create binary files instead of files with strings. The reason for this is that a lot of files are PDF, especially if you use google sheets & similar.